### PR TITLE
Remove serial printing

### DIFF
--- a/Adafruit_MPL3115A2.cpp
+++ b/Adafruit_MPL3115A2.cpp
@@ -45,7 +45,6 @@ Adafruit_MPL3115A2::Adafruit_MPL3115A2() {
 boolean Adafruit_MPL3115A2::begin() {
   Wire.begin();
   uint8_t whoami = read8(MPL3115A2_WHOAMI);
-  Serial.println(whoami, HEX);
   if (whoami != 0xC4) {
     return false;
   }
@@ -169,8 +168,6 @@ uint8_t Adafruit_MPL3115A2::read8(uint8_t a) {
 }
 
 void Adafruit_MPL3115A2::write8(uint8_t a, uint8_t d) {
-  Serial.print("Writing $"); Serial.print(a, HEX); 
-  Serial.print(" = 0x"); Serial.println(d, HEX);
   Wire.beginTransmission(MPL3115A2_ADDRESS); // start transmission to device 
   Wire.write(a); // sends register address to write to
   Wire.write(d); // sends register data


### PR DESCRIPTION
I'm a bit puzzled by the serial print statements in this code.
I sometimes forget to remove my debugging, but these seem to be there _on purpose_.
Why?

Random printouts are not something I expect from a library.

p.s. Sparkfun also has a library for the exact same chip. Is there any cooperation between you guys?
