### PR TITLE
Altitude calibration

### DIFF
--- a/Adafruit_MPL3115A2.cpp
+++ b/Adafruit_MPL3115A2.cpp
@@ -118,19 +118,12 @@ float Adafruit_MPL3115A2::getAltitude() {
   Wire.endTransmission(false); // end transmission
   
   Wire.requestFrom((uint8_t)MPL3115A2_ADDRESS, (uint8_t)3);// send data n-bytes read
-  alt = Wire.read(); // receive DATA
-  alt <<= 8;
-  alt |= Wire.read(); // receive DATA
-  alt <<= 8;
-  alt |= Wire.read(); // receive DATA
-  alt >>= 4;
-
-  if (alt & 0x800000) {
-    alt |= 0xFF000000;
-  }
+  alt  = ((uint32_t)Wire.read()) << 24; // receive DATA
+  alt |= ((uint32_t)Wire.read()) << 16; // receive DATA
+  alt |= ((uint32_t)Wire.read()) << 8; // receive DATA
 
   float altitude = alt;
-  altitude /= 16.0;
+  altitude /= 65536.0;
   return altitude;
 }
 

--- a/Adafruit_MPL3115A2.cpp
+++ b/Adafruit_MPL3115A2.cpp
@@ -129,6 +129,20 @@ float Adafruit_MPL3115A2::getAltitude() {
 
 /**************************************************************************/
 /*!
+    @brief  Set the local sea level barometric pressure
+*/
+/**************************************************************************/
+void Adafruit_MPL3115A2::setSeaPressure(float pascal) {
+  uint16_t bar = pascal/2;
+  Wire.beginTransmission(MPL3115A2_ADDRESS);
+  Wire.write((uint8_t)MPL3115A2_BAR_IN_MSB);
+  Wire.write((uint8_t)(bar>>8));
+  Wire.write((uint8_t)bar);
+  Wire.endTransmission(false);
+}
+
+/**************************************************************************/
+/*!
     @brief  Gets the floating-point temperature in Centigrade
 */
 /**************************************************************************/

--- a/Adafruit_MPL3115A2.h
+++ b/Adafruit_MPL3115A2.h
@@ -59,6 +59,9 @@
     #define MPL3115A2_OUT_T_DELTA_MSB               (0x0A)
     #define MPL3115A2_OUT_T_DELTA_LSB               (0x0B)
 
+    #define MPL3115A2_BAR_IN_MSB                    (0x14)
+    #define MPL3115A2_BAR_IN_LSB                    (0x15)
+
     #define MPL3115A2_WHOAMI                        (0x0C)
 
 #define MPL3115A2_PT_DATA_CFG 0x13
@@ -96,6 +99,7 @@ class Adafruit_MPL3115A2{
   float getPressure(void);
   float getAltitude(void);
   float getTemperature(void);
+  void setSeaPressure(float pascal);
 
   void write8(uint8_t a, uint8_t d);
 


### PR DESCRIPTION
This chip has the option to set the local sea level air pressure to calibrate the altimeter reading.
Without this change, it's not uncommon to see altimeter readings that are dozens of meters in the sky or below the ground. With this change it's within a meter.

Note that I'm not using the actual sea level pressure, just the current reading, effectively calibrating it to ground level. This is precisely what I want for my RC plane.

I also fixed and tested negative altitudes in the process. They where still broken.
