### PR TITLE
Async

### DIFF
--- a/Adafruit_MPL3115A2.cpp
+++ b/Adafruit_MPL3115A2.cpp
@@ -37,7 +37,7 @@
 
 #include <Wire.h>
 
-#include "Adafruit_MPL3115A2async.h"
+#include "Adafruit_MPL3115A2.h"
 
 /**************************************************************************/
 /*!

--- a/Adafruit_MPL3115A2.cpp
+++ b/Adafruit_MPL3115A2.cpp
@@ -21,6 +21,7 @@
  * @section author Author
  *
  * Written by Kevin "KTOWN" Townsend for Adafruit Industries.
+ * Updated with code for polled mode by A. Fitzhugh.
  *
  * @section license License
  *
@@ -36,7 +37,7 @@
 
 #include <Wire.h>
 
-#include "Adafruit_MPL3115A2.h"
+#include "Adafruit_MPL3115A2async.h"
 
 /**************************************************************************/
 /*!
@@ -72,9 +73,9 @@ boolean Adafruit_MPL3115A2::begin(TwoWire *twoWire) {
   write8(MPL3115A2_CTRL_REG1, _ctrl_reg1.reg);
 
   write8(MPL3115A2_PT_DATA_CFG, 
-	 MPL3115A2_PT_DATA_CFG_TDEFE |
-	 MPL3115A2_PT_DATA_CFG_PDEFE |
-	 MPL3115A2_PT_DATA_CFG_DREM);
+   MPL3115A2_PT_DATA_CFG_TDEFE |
+   MPL3115A2_PT_DATA_CFG_PDEFE |
+   MPL3115A2_PT_DATA_CFG_DREM);
   return true;
 }
 
@@ -233,4 +234,210 @@ void Adafruit_MPL3115A2::write8(uint8_t a, uint8_t d) {
   _i2c->write(a); // sends register address to write to
   _i2c->write(d); // sends register data
   _i2c->endTransmission(false); // end transmission
+}
+
+
+/**************************************************************************/
+/*!
+    @brief  Instantiates a new MPL3115A2 class
+*/
+/**************************************************************************/
+Adafruit_MPL3115A2async::Adafruit_MPL3115A2async() {
+}
+
+/**************************************************************************/
+/*!
+    @brief returns the state of the polling cycle
+    @param none
+    @return number representing the state of the reader (0 to 10) where 0 = uninitialised
+*/
+/**************************************************************************/
+unsigned int Adafruit_MPL3115A2async::getstate(){
+  return state;
+}
+
+/**************************************************************************/
+/*!
+    @brief  Setups the HW (reads coefficients values, etc.)
+    @param twoWire Optional TwoWire I2C object
+    @return true on successful startup, false otherwise
+*/
+/**************************************************************************/
+boolean Adafruit_MPL3115A2async::begin(TwoWire *twoWire) {
+  if (Adafruit_MPL3115A2::begin(twoWire)) {
+    // record in the state that we have been initalised.
+    state = 1;
+    return true;
+  } else {
+    return false;
+  }
+}
+
+/**************************************************************************/
+/*!
+    @brief  Gets the floating-point pressure level in kPa
+    @return altitude reading as a floating point value
+*/
+/**************************************************************************/
+float Adafruit_MPL3115A2async::getPressure() {
+  return baro;
+}
+/**************************************************************************/
+/*!
+    @brief  Gets the floating-point altitude value
+    @return altitude reading as a floating-point value
+*/
+/**************************************************************************/
+float Adafruit_MPL3115A2async::getTemperature() {
+  return temp;
+}
+/**************************************************************************/
+/*!
+    @brief  Gets the floating-point temperature in Centigrade
+    @return temperature reading in Centigrade as a floating-point value
+*/
+/**************************************************************************/
+float Adafruit_MPL3115A2async::getAltitude() {
+  return altitude;
+}
+/**************************************************************************/
+/*!
+    @brief  Boolean indicating whether data has been refreshed since last reset
+    @return true if data is new
+*/
+/**************************************************************************/
+bool Adafruit_MPL3115A2async::isNewData() {
+  return (state>=100);
+}
+/**************************************************************************/
+/*!
+    @brief  sets the data as old so we can tell when new data is read
+*/
+/**************************************************************************/
+void Adafruit_MPL3115A2async::reset(bool reset) {
+  if (reset && state>=100) state-=100;
+}
+
+/**************************************************************************/
+/*!
+    @brief  needs to be called regularly to update the pressures and temperatures
+    @param  boolean: false = do as much as possible (slower per call, fewer calls to refresh);
+    @param           true = small steps (faster per call, more calls to refresh)
+*/
+/**************************************************************************/
+void Adafruit_MPL3115A2async::poll(bool quick) {
+  uint32_t pressure;
+  int32_t alt;
+  int16_t t;
+  uint8_t sta;
+
+  switch (state){
+  default:     // unknown state - assume we aren't initialised
+    state=0;
+    break;
+  case 0:     // we weren't initialised with begin(); do nothing.
+    break;
+  case 1:     // reading pressure   
+  case 101:     // reading pressure   
+    if ((read8(MPL3115A2_CTRL_REG1) & MPL3115A2_CTRL_REG1_OST)) break;
+    state++;
+    if (quick) break;
+  case 2:     // 
+  case 102:     // 
+    _ctrl_reg1.bit.ALT = 0;
+    write8(MPL3115A2_CTRL_REG1, _ctrl_reg1.reg);
+  
+    _ctrl_reg1.bit.OST = 1;
+    write8(MPL3115A2_CTRL_REG1, _ctrl_reg1.reg);
+  
+    state++;
+    if (quick) break;
+  case 3:     // 
+  case 103:     // 
+    sta = read8(MPL3115A2_REGISTER_STATUS);
+    if (!(sta & MPL3115A2_REGISTER_STATUS_PDR)) break;
+    state++;
+    if (quick) break;
+  case 4:     // 
+  case 104:     // 
+    _i2c->beginTransmission(MPL3115A2_ADDRESS); // start transmission to device 
+    _i2c->write(MPL3115A2_REGISTER_PRESSURE_MSB); 
+    _i2c->endTransmission(false); // end transmission
+    
+    _i2c->requestFrom((uint8_t)MPL3115A2_ADDRESS, (uint8_t)3);// send data n-bytes read
+    pressure = _i2c->read(); // receive DATA
+    pressure <<= 8;
+    pressure |= _i2c->read(); // receive DATA
+    pressure <<= 8;
+    pressure |= _i2c->read(); // receive DATA
+    pressure >>= 4;
+  
+    baro = pressure;
+    baro /= 4.0;
+    state++;
+    if (quick) break;
+  case 5:     // read altitude 
+  case 105:     // read altitude 
+    if ((read8(MPL3115A2_CTRL_REG1) & MPL3115A2_CTRL_REG1_OST)) break;
+    state++;
+    if (quick) break;
+  case 6:     // 
+  case 106:     // 
+    _ctrl_reg1.bit.ALT = 1;
+    write8(MPL3115A2_CTRL_REG1, _ctrl_reg1.reg);
+  
+    _ctrl_reg1.bit.OST = 1;
+    write8(MPL3115A2_CTRL_REG1, _ctrl_reg1.reg);
+  
+    state++;
+    if (quick) break;
+  case 7:     // 
+  case 107:     // 
+    sta = read8(MPL3115A2_REGISTER_STATUS);
+    if (! (sta & MPL3115A2_REGISTER_STATUS_PDR)) break;
+    state++;
+    if (!quick) break;
+  case 8:     // 
+  case 108:     // 
+    _i2c->beginTransmission(MPL3115A2_ADDRESS); // start transmission to device 
+    _i2c->write(MPL3115A2_REGISTER_PRESSURE_MSB); 
+    _i2c->endTransmission(false); // end transmission
+    
+    _i2c->requestFrom((uint8_t)MPL3115A2_ADDRESS, (uint8_t)3);// send data n-bytes read
+    alt  = ((uint32_t)_i2c->read()) << 24; // receive DATA
+    alt |= ((uint32_t)_i2c->read()) << 16; // receive DATA
+    alt |= ((uint32_t)_i2c->read()) << 8; // receive DATA
+  
+    altitude = alt;
+    altitude /= 65536.0;
+
+    state++;
+    if (quick) break;
+  case 9:     // read temperature
+  case 109:     // read temperature
+    sta = read8(MPL3115A2_REGISTER_STATUS);
+    if (! (sta & MPL3115A2_REGISTER_STATUS_TDR)) break;
+    state++;
+    if (quick) break;
+  case 10:     // 
+  case 110:     // 
+    _i2c->beginTransmission(MPL3115A2_ADDRESS); // start transmission to device 
+    _i2c->write(MPL3115A2_REGISTER_TEMP_MSB); 
+    _i2c->endTransmission(false); // end transmission
+    
+    _i2c->requestFrom((uint8_t)MPL3115A2_ADDRESS, (uint8_t)2);// send data n-bytes read
+    t = _i2c->read(); // receive DATA
+    t <<= 8;
+    t |= _i2c->read(); // receive DATA
+    t >>= 4;
+    
+    if (t & 0x800) {
+      t |= 0xF000;
+    }
+  
+    temp = t;
+    temp /= 16.0;
+    state=101;              // state >100 implies new data
+    break;
+  }
 }

--- a/Adafruit_MPL3115A2.cpp
+++ b/Adafruit_MPL3115A2.cpp
@@ -203,9 +203,6 @@ float Adafruit_MPL3115A2::getTemperature() {
   return temp;
 }
 
-
-
-
 /**************************************************************************/
 /*!
     @brief  read 1 byte of data at the specified address
@@ -239,7 +236,7 @@ void Adafruit_MPL3115A2::write8(uint8_t a, uint8_t d) {
 
 /**************************************************************************/
 /*!
-    @brief  Instantiates a new MPL3115A2 class
+    @brief  Instantiates a new MPL3115A2 class for polled mode
 */
 /**************************************************************************/
 Adafruit_MPL3115A2async::Adafruit_MPL3115A2async() {
@@ -249,7 +246,8 @@ Adafruit_MPL3115A2async::Adafruit_MPL3115A2async() {
 /*!
     @brief returns the state of the polling cycle
     @param none
-    @return number representing the state of the reader (0 to 10) where 0 = uninitialised
+    @return unsigned int representing the state of the reader (0 to 10 or 101-110) 
+	    where 0 = uninitialised and >100 implies data has been refresehd since reset
 */
 /**************************************************************************/
 unsigned int Adafruit_MPL3115A2async::getstate(){
@@ -322,7 +320,7 @@ void Adafruit_MPL3115A2async::reset(bool reset) {
 /*!
     @brief  needs to be called regularly to update the pressures and temperatures
     @param  boolean: false = do as much as possible (slower per call, fewer calls to refresh);
-    @param           true = small steps (faster per call, more calls to refresh)
+                     true = small steps (faster per call, more calls to refresh)
 */
 /**************************************************************************/
 void Adafruit_MPL3115A2async::poll(bool quick) {
@@ -342,8 +340,8 @@ void Adafruit_MPL3115A2async::poll(bool quick) {
     if ((read8(MPL3115A2_CTRL_REG1) & MPL3115A2_CTRL_REG1_OST)) break;
     state++;
     if (quick) break;
-  case 2:     // 
-  case 102:     // 
+  case 2:
+  case 102:
     _ctrl_reg1.bit.ALT = 0;
     write8(MPL3115A2_CTRL_REG1, _ctrl_reg1.reg);
   
@@ -358,8 +356,8 @@ void Adafruit_MPL3115A2async::poll(bool quick) {
     if (!(sta & MPL3115A2_REGISTER_STATUS_PDR)) break;
     state++;
     if (quick) break;
-  case 4:     // 
-  case 104:     // 
+  case 4:
+  case 104:
     _i2c->beginTransmission(MPL3115A2_ADDRESS); // start transmission to device 
     _i2c->write(MPL3115A2_REGISTER_PRESSURE_MSB); 
     _i2c->endTransmission(false); // end transmission
@@ -381,8 +379,8 @@ void Adafruit_MPL3115A2async::poll(bool quick) {
     if ((read8(MPL3115A2_CTRL_REG1) & MPL3115A2_CTRL_REG1_OST)) break;
     state++;
     if (quick) break;
-  case 6:     // 
-  case 106:     // 
+  case 6:
+  case 106:
     _ctrl_reg1.bit.ALT = 1;
     write8(MPL3115A2_CTRL_REG1, _ctrl_reg1.reg);
   
@@ -391,14 +389,14 @@ void Adafruit_MPL3115A2async::poll(bool quick) {
   
     state++;
     if (quick) break;
-  case 7:     // 
-  case 107:     // 
+  case 7:
+  case 107:
     sta = read8(MPL3115A2_REGISTER_STATUS);
     if (! (sta & MPL3115A2_REGISTER_STATUS_PDR)) break;
     state++;
     if (!quick) break;
-  case 8:     // 
-  case 108:     // 
+  case 8:
+  case 108:
     _i2c->beginTransmission(MPL3115A2_ADDRESS); // start transmission to device 
     _i2c->write(MPL3115A2_REGISTER_PRESSURE_MSB); 
     _i2c->endTransmission(false); // end transmission
@@ -419,8 +417,8 @@ void Adafruit_MPL3115A2async::poll(bool quick) {
     if (! (sta & MPL3115A2_REGISTER_STATUS_TDR)) break;
     state++;
     if (quick) break;
-  case 10:     // 
-  case 110:     // 
+  case 10:
+  case 110:
     _i2c->beginTransmission(MPL3115A2_ADDRESS); // start transmission to device 
     _i2c->write(MPL3115A2_REGISTER_TEMP_MSB); 
     _i2c->endTransmission(false); // end transmission

--- a/Adafruit_MPL3115A2.cpp
+++ b/Adafruit_MPL3115A2.cpp
@@ -245,7 +245,6 @@ Adafruit_MPL3115A2async::Adafruit_MPL3115A2async() {
 /**************************************************************************/
 /*!
     @brief returns the state of the polling cycle
-    @param none
     @return unsigned int representing the state of the reader (0 to 10 or 101-110) 
 	    where 0 = uninitialised and >100 implies data has been refresehd since reset
 */
@@ -310,6 +309,7 @@ bool Adafruit_MPL3115A2async::isNewData() {
 /**************************************************************************/
 /*!
     @brief  sets the data as old so we can tell when new data is read
+    @param  reset pass true to reset, false to leave unchanged
 */
 /**************************************************************************/
 void Adafruit_MPL3115A2async::reset(bool reset) {
@@ -319,8 +319,7 @@ void Adafruit_MPL3115A2async::reset(bool reset) {
 /**************************************************************************/
 /*!
     @brief  needs to be called regularly to update the pressures and temperatures
-    @param  boolean: false = do as much as possible (slower per call, fewer calls to refresh);
-                     true = small steps (faster per call, more calls to refresh)
+    @param  quick false is slower per call, fewer calls to refresh; true is faster per call, more calls to refresh
 */
 /**************************************************************************/
 void Adafruit_MPL3115A2async::poll(bool quick) {

--- a/Adafruit_MPL3115A2.h
+++ b/Adafruit_MPL3115A2.h
@@ -13,6 +13,7 @@
  * products from Adafruit!
  *
  * Written by Kevin "KTOWN" Townsend for Adafruit Industries.
+ * Updated with code for polled mode by A. Fitzhugh.
  *
  * BSD license, all text here must be included in any redistribution.
  *
@@ -29,7 +30,6 @@
 #else
  #include <Wire.h>
 #endif
-
 
 #define MPL3115A2_ADDRESS                       (0x60)    ///< default I2C address 1100000
 
@@ -152,7 +152,7 @@ class Adafruit_MPL3115A2{
 
   void write8(uint8_t a, uint8_t d);
 
- private:
+ protected:
   TwoWire *_i2c;
   uint8_t read8(uint8_t a);
   uint8_t mode;
@@ -170,4 +170,29 @@ class Adafruit_MPL3115A2{
   } ctrl_reg1;
   ctrl_reg1 _ctrl_reg1;
 
+};
+
+/**************************************************************************/
+/*! 
+    @brief  Class that stores state and functions for interacting with MPL3115A2 altimeter
+*/
+/**************************************************************************/
+class Adafruit_MPL3115A2async : public Adafruit_MPL3115A2{
+ public:
+  Adafruit_MPL3115A2async();
+  float getPressure(void);
+  float getAltitude(void);
+  float getTemperature(void);
+  void poll(bool quick = true);
+  unsigned int getstate();
+  bool isNewData();
+  void reset(bool reset=true);
+
+  boolean begin(TwoWire *twoWire);
+
+ protected:
+  float baro=NAN;
+  float temp=NAN;
+  float altitude=NAN;
+  uint8_t state=0;
 };

--- a/Adafruit_MPL3115A2.h
+++ b/Adafruit_MPL3115A2.h
@@ -174,7 +174,7 @@ class Adafruit_MPL3115A2{
 
 /**************************************************************************/
 /*! 
-    @brief  Class that stores state and functions for interacting with MPL3115A2 altimeter
+    @brief  Derived class that stores state and functions for interacting with MPL3115A2 altimeter in polled mode
 */
 /**************************************************************************/
 class Adafruit_MPL3115A2async : public Adafruit_MPL3115A2{

--- a/examples/readMPL3115A2async.cpp
+++ b/examples/readMPL3115A2async.cpp
@@ -1,0 +1,67 @@
+/**************************************************************************/
+/*!
+    @file     Adafruit_MPL3115A2async.cpp
+    @author   A. Fitzhugh
+    @license  BSD (see license.txt)
+
+    Example for the MPL3115A2 barometric pressure sensor, being read in polled mode
+
+    This is a library for the Adafruit MPL3115A2 breakout
+    ----> https://www.adafruit.com/products/1893
+
+    Adafruit invests time and resources providing this open source code,
+    please support Adafruit and open-source hardware by purchasing
+    products from Adafruit!
+
+    @section  HISTORY
+
+    v1.0 - First release
+*/
+/**************************************************************************/
+
+#include "Adafruit_MPL3115A2async.h"
+
+// Power by connecting Vin to 3-5V, GND to GND
+// Uses I2C - connect SCL to the SCL pin, SDA to SDA pin
+// See the Wire tutorial for pinouts for each Arduino
+// http://arduino.cc/en/reference/wire
+Adafruit_MPL3115A2async baro = Adafruit_MPL3115A2async();
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println("Adafruit_MPL3115A2 test!");
+
+  // we're need to initialise this here so we can set the clock speed later
+  TwoWire myi2c;
+
+  // we don't need to block here - baro.poll is quick if the initialisation wasn't succesfull
+  if (!baro.begin(&myi2c)) {
+    Serial.println("Couldnt find sensor");
+  }
+  
+  // a lot of the time for the loop is determined by i2c communications - set this as high as possible.
+  myi2c.setClock(400000);    // fast mode
+}
+
+void loop() {
+
+  // poll is required to update data in background.
+  // Here we are using quick=true to make loop run as fast as possible
+  baro.poll(true);
+
+  // read the data. Doesn't wait and we'll automatically get updated data when available
+  float pascals = baro.getPressure();
+  float tempC = baro.getTemperature();
+  float altm = baro.getAltitude();
+
+  // isNewData() shows when we have new data available and can be used to trigger further actions
+  if (baro.isNewData()){ 
+    // display data
+    Serial.print(pascals/1000); Serial.print(" Pressure (kPa)     ");
+    Serial.print(altm); Serial.print(" meters     ");
+    Serial.print(tempC); Serial.print("*C");
+    // and goto next line
+    Serial.println();
+    baro.reset();             // needed only to reset isNewData()
+  }
+}

--- a/examples/readMPL3115A2async/readMPL3115A2async.ino
+++ b/examples/readMPL3115A2async/readMPL3115A2async.ino
@@ -19,13 +19,20 @@
 */
 /**************************************************************************/
 
-#include "Adafruit_MPL3115A2async.h"
+#include "Adafruit_MPL3115A2.h"
 
 // Power by connecting Vin to 3-5V, GND to GND
 // Uses I2C - connect SCL to the SCL pin, SDA to SDA pin
 // See the Wire tutorial for pinouts for each Arduino
 // http://arduino.cc/en/reference/wire
 Adafruit_MPL3115A2async baro = Adafruit_MPL3115A2async();
+
+// a counter to show how many loops we execute between sensor updates
+unsigned long counter;
+// and record the time
+unsigned long timer;
+unsigned long maxtime;
+unsigned long mintime;
 
 void setup() {
   Serial.begin(115200);
@@ -41,27 +48,51 @@ void setup() {
   
   // a lot of the time for the loop is determined by i2c communications - set this as high as possible.
   myi2c.setClock(400000);    // fast mode
+
+  // initialise stats
+  counter = 0;
+  maxtime = 0;
+  mintime = -1;
 }
 
 void loop() {
 
   // poll is required to update data in background.
   // Here we are using quick=true to make loop run as fast as possible
+  unsigned long start = micros();
   baro.poll(true);
-
   // read the data. Doesn't wait and we'll automatically get updated data when available
   float pascals = baro.getPressure();
   float tempC = baro.getTemperature();
   float altm = baro.getAltitude();
+  unsigned long duration = micros() - start;
+
+  // update the counter
+  counter++;
+
+
+  // update max/min
+  if (duration > maxtime) maxtime = duration; 
+  if (duration < mintime) mintime = duration; 
 
   // isNewData() shows when we have new data available and can be used to trigger further actions
   if (baro.isNewData()){ 
     // display data
     Serial.print(pascals/1000); Serial.print(" Pressure (kPa)     ");
     Serial.print(altm); Serial.print(" meters     ");
-    Serial.print(tempC); Serial.print("*C");
+    Serial.print(tempC); Serial.print("*C     ");
+    Serial.print(counter); Serial.print(" loops executed of which, sensor update took ");
+    Serial.print(mintime); Serial.print(" to ");
+    Serial.print(maxtime); Serial.print(" microseconds");
     // and goto next line
     Serial.println();
-    baro.reset();             // needed only to reset isNewData()
+
+    // needed only to reset isNewData()
+    baro.reset();             
+
+    // reset stats
+    counter = 0;
+    maxtime = 0;
+    mintime = -1;
   }
 }

--- a/examples/readMPL3115A2async/readMPL3115A2async.ino
+++ b/examples/readMPL3115A2async/readMPL3115A2async.ino
@@ -19,6 +19,7 @@
 */
 /**************************************************************************/
 
+#include <Wire.h>
 #include "Adafruit_MPL3115A2.h"
 
 // Power by connecting Vin to 3-5V, GND to GND

--- a/examples/readMPL3115A2async/readMPL3115A2async.ino
+++ b/examples/readMPL3115A2async/readMPL3115A2async.ino
@@ -19,8 +19,8 @@
 */
 /**************************************************************************/
 
-#include <Wire.h>
 #include "Adafruit_MPL3115A2.h"
+#include <Wire.h>
 
 // Power by connecting Vin to 3-5V, GND to GND
 // Uses I2C - connect SCL to the SCL pin, SDA to SDA pin
@@ -40,15 +40,15 @@ void setup() {
   Serial.println("Adafruit_MPL3115A2 test!");
 
   // we're need to initialise this here so we can set the clock speed later
-  TwoWire myi2c;
+  TwoWire *myi2c = &Wire;
 
   // we don't need to block here - baro.poll is quick if the initialisation wasn't succesfull
-  if (!baro.begin(&myi2c)) {
+  if (!baro.begin(myi2c)) {
     Serial.println("Couldnt find sensor");
   }
   
   // a lot of the time for the loop is determined by i2c communications - set this as high as possible.
-  myi2c.setClock(400000);    // fast mode
+  myi2c->setClock(400000);    // fast mode
 
   // initialise stats
   counter = 0;
@@ -71,8 +71,7 @@ void loop() {
   // update the counter
   counter++;
 
-
-  // update max/min
+  // update max/min timings
   if (duration > maxtime) maxtime = duration; 
   if (duration < mintime) mintime = duration; 
 


### PR DESCRIPTION
This is a working draft of code to implement an asynchronous read. It extends the existing class so current code using the library should run unchanged. By changing the class instantiation to Adafruit_MPL3115A2async, and introducing a poll() call, the sensor read is split into small sections that are called on successive poll() calls, without any un-necessary delays. This allows it to be used in fast loops.

An example has been introduced into demonstrating this functionality.

Possible further work before final release:
* use enum for sates to make use clearer.
* change poll(bool) to poll(enum) to allow caller to limit data that is updated and achieve faster refresh.
* consider how to stop code blocking if communication with sensor is lost - I might need some advice on this!