### PR TITLE
Add initiate immediate measurement to getTemperature()

### DIFF
--- a/Adafruit_MPL3115A2.cpp
+++ b/Adafruit_MPL3115A2.cpp
@@ -164,6 +164,9 @@ void Adafruit_MPL3115A2::setSeaPressure(float pascal) {
 float Adafruit_MPL3115A2::getTemperature() {
   int16_t t;
 
+  _ctrl_reg1.bit.OST = 1;
+  write8(MPL3115A2_CTRL_REG1, _ctrl_reg1.reg);
+
   uint8_t sta = 0;
   while (!(sta & MPL3115A2_REGISTER_STATUS_TDR)) {
     sta = read8(MPL3115A2_REGISTER_STATUS);


### PR DESCRIPTION
Fixes #8.

`getTemperature()` was missing the setting of `OST` bit in `CTRL_REG1` to initiate a new measurement. So it would park forever waiting for a new measurement.

It would work if the other measurements were called first as those would set `TDR` in `DR_STATUS`, indicating a new temperature reading was available.

Tested on an UNO and MPL3115A2 with this sketch:
```cpp
#include <Wire.h>
#include <Adafruit_MPL3115A2.h>

Adafruit_MPL3115A2 mpl = Adafruit_MPL3115A2();

void setup() {
  Serial.begin(9600);
  Serial.println("Adafruit_MPL3115A2 test!");

  if (!mpl.begin()) {
    Serial.println("Couldnt find sensor");
    return;
  }
}

void loop() {
  Serial.println("getTemperature()"); float mpl_t = mpl.getTemperature();
  Serial.println("getPressure()"); float mpl_p = mpl.getPressure();
  Serial.println("getAltitude()"); float mpl_a = mpl.getAltitude();

  Serial.print("t = "); Serial.println(mpl_t);
  Serial.print("p = "); Serial.println(mpl_p);
  Serial.print("a = "); Serial.println(mpl_a);

  delay(250);
}
```