### PR TITLE
Convert to BusIO plus some other (breaking) tweaks

### DIFF
--- a/Adafruit_MPL3115A2.cpp
+++ b/Adafruit_MPL3115A2.cpp
@@ -28,10 +28,6 @@
  *
  */
 
-#include "Arduino.h"
-
-#include <Wire.h>
-
 #include "Adafruit_MPL3115A2.h"
 
 /*!
@@ -46,150 +42,130 @@ Adafruit_MPL3115A2::Adafruit_MPL3115A2() {}
  *   @return true on successful startup, false otherwise
  */
 boolean Adafruit_MPL3115A2::begin(TwoWire *twoWire) {
-  _i2c = twoWire;
-  _i2c->begin();
+  if (i2c_dev)
+    delete i2c_dev;
+  i2c_dev = new Adafruit_I2CDevice(MPL3115A2_ADDRESS, twoWire);
+  if (!i2c_dev->begin())
+    return false;
+
+  // sanity check
   uint8_t whoami = read8(MPL3115A2_WHOAMI);
   if (whoami != 0xC4) {
     return false;
   }
 
+  // software reset
   write8(MPL3115A2_CTRL_REG1, MPL3115A2_CTRL_REG1_RST);
-  delay(10);
-
   while (read8(MPL3115A2_CTRL_REG1) & MPL3115A2_CTRL_REG1_RST)
     delay(10);
 
+  // set oversampling and altitude mode
   _ctrl_reg1.reg = MPL3115A2_CTRL_REG1_OS128 | MPL3115A2_CTRL_REG1_ALT;
-
   write8(MPL3115A2_CTRL_REG1, _ctrl_reg1.reg);
 
+  // enable data ready events for pressure/altitude and temperature
   write8(MPL3115A2_PT_DATA_CFG, MPL3115A2_PT_DATA_CFG_TDEFE |
                                     MPL3115A2_PT_DATA_CFG_PDEFE |
                                     MPL3115A2_PT_DATA_CFG_DREM);
+
   return true;
 }
 
 /*!
- *  @brief  Gets the floating-point pressure level in kPa
- *  @return altitude reading as a floating point value
+ *  @brief  Get barometric pressure
+ *  @return pressure reading as a floating point value in hPa
  */
 float Adafruit_MPL3115A2::getPressure() {
-  uint32_t pressure;
-
+  // wait for one-shot to clear before proceeding
   while (read8(MPL3115A2_CTRL_REG1) & MPL3115A2_CTRL_REG1_OST)
     delay(10);
 
-  _ctrl_reg1.bit.ALT = 0;
+  // configure and initiate measurement
+  _ctrl_reg1.bit.ALT = 0; // barometer (pressure) mode
+  _ctrl_reg1.bit.OST = 1; // initatiate a one-shot measurement
   write8(MPL3115A2_CTRL_REG1, _ctrl_reg1.reg);
 
-  _ctrl_reg1.bit.OST = 1;
-  write8(MPL3115A2_CTRL_REG1, _ctrl_reg1.reg);
-
-  uint8_t sta = 0;
-  while (!(sta & MPL3115A2_REGISTER_STATUS_PDR)) {
-    sta = read8(MPL3115A2_REGISTER_STATUS);
+  // poll status to wait for conversion complete
+  while (!(read8(MPL3115A2_REGISTER_STATUS) & MPL3115A2_REGISTER_STATUS_PDR))
     delay(10);
-  }
-  _i2c->beginTransmission(MPL3115A2_ADDRESS); // start transmission to device
-  _i2c->write(MPL3115A2_REGISTER_PRESSURE_MSB);
-  _i2c->endTransmission(false); // end transmission
 
-  _i2c->requestFrom((uint8_t)MPL3115A2_ADDRESS,
-                    (uint8_t)3); // send data n-bytes read
-  pressure = _i2c->read();       // receive DATA
-  pressure <<= 8;
-  pressure |= _i2c->read(); // receive DATA
-  pressure <<= 8;
-  pressure |= _i2c->read(); // receive DATA
-  pressure >>= 4;
-
-  float baro = pressure;
-  baro /= 4.0;
-  return baro;
+  // read data
+  uint32_t pressure;
+  uint8_t buffer[5] = {MPL3115A2_REGISTER_PRESSURE_MSB, 0, 0, 0, 0};
+  i2c_dev->write_then_read(buffer, 1, buffer, 5);
+  pressure = uint32_t(buffer[0]) << 16 | uint32_t(buffer[1]) << 8 |
+             uint32_t(buffer[2]);
+  return float(pressure) / 6400.0;
 }
 
 /*!
- *  @brief  Gets the floating-point altitude value
- *  @return altitude reading as a floating-point value
+ *  @brief  Get altitude
+ *  @return altitude reading as a floating-point value in meters
  */
 float Adafruit_MPL3115A2::getAltitude() {
-  int32_t alt;
-
+  // wait for one-shot to clear before proceeding
   while (read8(MPL3115A2_CTRL_REG1) & MPL3115A2_CTRL_REG1_OST)
     delay(10);
 
-  _ctrl_reg1.bit.ALT = 1;
+  // configure and initiate measurement
+  _ctrl_reg1.bit.ALT = 1; // altimeter mode
+  _ctrl_reg1.bit.OST = 1; // initatiate a one-shot measurement
   write8(MPL3115A2_CTRL_REG1, _ctrl_reg1.reg);
 
-  _ctrl_reg1.bit.OST = 1;
-  write8(MPL3115A2_CTRL_REG1, _ctrl_reg1.reg);
-
-  uint8_t sta = 0;
-  while (!(sta & MPL3115A2_REGISTER_STATUS_PDR)) {
-    sta = read8(MPL3115A2_REGISTER_STATUS);
+  // poll status to wait for conversion complete
+  while (!(read8(MPL3115A2_REGISTER_STATUS) & MPL3115A2_REGISTER_STATUS_PDR))
     delay(10);
-  }
-  _i2c->beginTransmission(MPL3115A2_ADDRESS); // start transmission to device
-  _i2c->write(MPL3115A2_REGISTER_PRESSURE_MSB);
-  _i2c->endTransmission(false); // end transmission
 
-  _i2c->requestFrom((uint8_t)MPL3115A2_ADDRESS,
-                    (uint8_t)3);         // send data n-bytes read
-  alt = ((uint32_t)_i2c->read()) << 24;  // receive DATA
-  alt |= ((uint32_t)_i2c->read()) << 16; // receive DATA
-  alt |= ((uint32_t)_i2c->read()) << 8;  // receive DATA
-
-  float altitude = alt;
-  altitude /= 65536.0;
-  return altitude;
+  // read data
+  int32_t alt;
+  uint8_t buffer[5] = {MPL3115A2_REGISTER_PRESSURE_MSB, 0, 0, 0, 0};
+  i2c_dev->write_then_read(buffer, 1, buffer, 5);
+  alt = uint32_t(buffer[0]) << 24 | uint32_t(buffer[1]) << 16 |
+        uint32_t(buffer[2]) << 8;
+  return float(alt) / 65536.0;
 }
 
 /*!
- *  @brief  Set the local sea level barometric pressure
- *  @param pascal the pressure to use as the baseline
+ *  @brief  Set the local sea level pressure
+ *  @param SLP sea level pressure in hPa
  */
-void Adafruit_MPL3115A2::setSeaPressure(float pascal) {
-  uint16_t bar = pascal / 2;
-  _i2c->beginTransmission(MPL3115A2_ADDRESS);
-  _i2c->write((uint8_t)MPL3115A2_BAR_IN_MSB);
-  _i2c->write((uint8_t)(bar >> 8));
-  _i2c->write((uint8_t)bar);
-  _i2c->endTransmission(false);
+void Adafruit_MPL3115A2::setSeaPressure(float SLP) {
+  // multiply by 100 to convert hPa to Pa
+  // divide by 2 to convert to 2 Pa per LSB
+  // convert to integer
+  uint16_t bar = SLP * 50;
+
+  // write result to register
+  uint8_t buffer[3];
+  buffer[0] = MPL3115A2_BAR_IN_MSB;
+  buffer[1] = bar >> 8;
+  buffer[2] = bar & 0xFF;
+  i2c_dev->write(buffer, 3);
 }
 
 /*!
- *  @brief  Gets the floating-point temperature in Centigrade
- *  @return temperature reading in Centigrade as a floating-point value
+ *  @brief  Get temperature
+ *  @return temperature reading as a floating-point value in degC
  */
 float Adafruit_MPL3115A2::getTemperature() {
-  int16_t t;
+  // wait for one-shot to clear before proceeding
+  while (read8(MPL3115A2_CTRL_REG1) & MPL3115A2_CTRL_REG1_OST)
+    delay(10);
 
+  // initatiate a one-shot measurement
   _ctrl_reg1.bit.OST = 1;
   write8(MPL3115A2_CTRL_REG1, _ctrl_reg1.reg);
 
-  uint8_t sta = 0;
-  while (!(sta & MPL3115A2_REGISTER_STATUS_TDR)) {
-    sta = read8(MPL3115A2_REGISTER_STATUS);
+  // poll status to wait for conversion complete
+  while (!(read8(MPL3115A2_REGISTER_STATUS) & MPL3115A2_REGISTER_STATUS_PTDR))
     delay(10);
-  }
-  _i2c->beginTransmission(MPL3115A2_ADDRESS); // start transmission to device
-  _i2c->write(MPL3115A2_REGISTER_TEMP_MSB);
-  _i2c->endTransmission(false); // end transmission
 
-  _i2c->requestFrom((uint8_t)MPL3115A2_ADDRESS,
-                    (uint8_t)2); // send data n-bytes read
-  t = _i2c->read();              // receive DATA
-  t <<= 8;
-  t |= _i2c->read(); // receive DATA
-  t >>= 4;
-
-  if (t & 0x800) {
-    t |= 0xF000;
-  }
-
-  float temp = t;
-  temp /= 16.0;
-  return temp;
+  // read data
+  int16_t t;
+  uint8_t buffer[5] = {MPL3115A2_REGISTER_PRESSURE_MSB, 0, 0, 0, 0};
+  i2c_dev->write_then_read(buffer, 1, buffer, 5);
+  t = uint16_t(buffer[3]) << 8 | uint16_t(buffer[4]);
+  return float(t) / 256.0;
 }
 
 /*!
@@ -199,13 +175,9 @@ float Adafruit_MPL3115A2::getTemperature() {
  *  @return the read data byte
  */
 uint8_t Adafruit_MPL3115A2::read8(uint8_t a) {
-  _i2c->beginTransmission(MPL3115A2_ADDRESS); // start transmission to device
-  _i2c->write(a);               // sends register address to read from
-  _i2c->endTransmission(false); // end transmission
-
-  _i2c->requestFrom((uint8_t)MPL3115A2_ADDRESS,
-                    (uint8_t)1); // send data n-bytes read
-  return _i2c->read();           // receive DATA
+  uint8_t buffer[1] = {a};
+  i2c_dev->write_then_read(buffer, 1, buffer, 1);
+  return buffer[0];
 }
 
 /*!
@@ -216,8 +188,6 @@ uint8_t Adafruit_MPL3115A2::read8(uint8_t a) {
  *          the byte to write
  */
 void Adafruit_MPL3115A2::write8(uint8_t a, uint8_t d) {
-  _i2c->beginTransmission(MPL3115A2_ADDRESS); // start transmission to device
-  _i2c->write(a);               // sends register address to write to
-  _i2c->write(d);               // sends register data
-  _i2c->endTransmission(false); // end transmission
+  uint8_t buffer[2] = {a, d};
+  i2c_dev->write(buffer, 2);
 }

--- a/Adafruit_MPL3115A2.h
+++ b/Adafruit_MPL3115A2.h
@@ -22,7 +22,7 @@
 #define __MPL3115A2__
 
 #include "Arduino.h"
-#include <Wire.h>
+#include <Adafruit_I2CDevice.h>
 
 #define MPL3115A2_ADDRESS (0x60) ///< default I2C address 1100000
 
@@ -112,12 +112,12 @@ public:
   float getPressure(void);
   float getAltitude(void);
   float getTemperature(void);
-  void setSeaPressure(float pascal);
+  void setSeaPressure(float SLP);
 
   void write8(uint8_t a, uint8_t d);
 
 private:
-  TwoWire *_i2c;
+  Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
   uint8_t read8(uint8_t a);
   uint8_t mode;
 

--- a/examples/testmpl3115a2/testmpl3115a2.ino
+++ b/examples/testmpl3115a2/testmpl3115a2.ino
@@ -19,36 +19,35 @@
 */
 /**************************************************************************/
 
-#include <Wire.h>
 #include <Adafruit_MPL3115A2.h>
 
-// Power by connecting Vin to 3-5V, GND to GND
-// Uses I2C - connect SCL to the SCL pin, SDA to SDA pin
-// See the Wire tutorial for pinouts for each Arduino
-// http://arduino.cc/en/reference/wire
-Adafruit_MPL3115A2 baro = Adafruit_MPL3115A2();
+Adafruit_MPL3115A2 baro;
 
 void setup() {
   Serial.begin(9600);
+  while(!Serial);
   Serial.println("Adafruit_MPL3115A2 test!");
+
+  if (!baro.begin()) {
+    Serial.println("Could not find sensor. Check wiring.");
+    while(1);
+  }
+
+  // use to set sea level pressure for current location
+  // this is needed for accurate altitude measurement
+  // STD SLP = 1013.26 hPa
+  baro.setSeaPressure(1013.26);
 }
 
 void loop() {
-  if (! baro.begin()) {
-    Serial.println("Couldnt find sensor");
-    return;
-  }
-  
-  float pascals = baro.getPressure();
-  // Our weather page presents pressure in Inches (Hg)
-  // Use http://www.onlineconversion.com/pressure.htm for other units
-  Serial.print(pascals/3377); Serial.println(" Inches (Hg)");
+  float pressure = baro.getPressure();
+  float altitude = baro.getAltitude();
+  float temperature = baro.getTemperature();
 
-  float altm = baro.getAltitude();
-  Serial.print(altm); Serial.println(" meters");
-
-  float tempC = baro.getTemperature();
-  Serial.print(tempC); Serial.println("*C");
+  Serial.println("-----------------");
+  Serial.print("pressure = "); Serial.print(pressure); Serial.println(" hPa");
+  Serial.print("altitude = "); Serial.print(altitude); Serial.println(" m");
+  Serial.print("temperature = "); Serial.print(temperature); Serial.println(" C");
 
   delay(250);
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit MPL3115A2 Library
-version=1.2.4
+version=2.0.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for the MPL3115A2 sensors in the Adafruit shop
@@ -7,4 +7,4 @@ paragraph=Arduino library for the MPL3115A2 sensors in the Adafruit shop
 category=Sensors
 url=https://github.com/adafruit/Adafruit_MPL3115A2_Library
 architectures=*
-depends=Adafruit ILI9341
+depends=Adafruit ILI9341, Adafruit BusIO


### PR DESCRIPTION
### **BREAKING CHANGES**

For #20, but with some extra modifications.

Noticed that the existing example sketch was calling `begin()` in the `loop()`, but wasn't obvious why. Moved it to `setup()` and it worked, but only for the first loop. Several rabbit holes later, seems to have been related to directly reading the temperature register ***without*** reading the pressure registers in `getTemperature()`. It doesn't seem to like that. Reading all 5 data registers, `0x01` to `0x05`, seems to fix the issue.

Changed various units to be more inline with standard, Pa->hPa. Updated example sketch.

Tested on QTPY.

![Screenshot from 2021-09-09 18-13-12](https://user-images.githubusercontent.com/8755041/132782900-ff47a85c-1c66-4316-a21f-6b01ca55bf6c.png)
