### PR TITLE
Remove superfluous dependency.

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Arduino library for the MPL3115A2 sensors in the Adafruit shop
 category=Sensors
 url=https://github.com/adafruit/Adafruit_MPL3115A2_Library
 architectures=*
-depends=Adafruit ILI9341, Adafruit BusIO
+depends=Adafruit BusIO


### PR DESCRIPTION
The MPL3115A2 library does not depend on a Touch Screen library.
