### PR TITLE
Non-blocking reads of pressure data.

### DIFF
--- a/Adafruit_MPL3115A2.cpp
+++ b/Adafruit_MPL3115A2.cpp
@@ -102,38 +102,36 @@ float Adafruit_MPL3115A2::getPressure() {
 /*!
  *  @brief Get barometric pressure, non-blocking.
  *  @param pressure Sensed pressure in hPa.
- *  @return phase of the read operation. Returns 0 if pressure was written with valid data. Returns non-zero when function needs to be called again.
+ *  @return phase of the read operation. Returns 0 if pressure was written with
+ * valid data. Returns non-zero when function needs to be called again.
  */
-uint8_t Adafruit_MPL3115A2::getPressureNonBlocking(float& pressure)
-{
+uint8_t Adafruit_MPL3115A2::getPressureNonBlocking(float &pressure) {
   uint32_t pval;
   uint8_t wbuf[1] = {MPL3115A2_REGISTER_PRESSURE_MSB};
-  uint8_t rbuf[5] = {0,0,0,0,0};
-  switch(nbphase)
-  {
-    case MPL3115A2_PHASE_VIRGIN:
-    case MPL3115A2_PHASE_COMPLETE:
-      // Start a new measurement cycle.
-      _ctrl_reg1.bit.ALT = 0; // barometer (pressure) mode
-      _ctrl_reg1.bit.OST = 1; // initatiate a one-shot measurement
-      write8(MPL3115A2_CTRL_REG1, _ctrl_reg1.reg);
-      nbphase = MPL3115A2_PHASE_REQUESTED;
-      break;
-    case MPL3115A2_PHASE_REQUESTED:
-      if (read8(MPL3115A2_REGISTER_STATUS) & MPL3115A2_REGISTER_STATUS_PDR)
+  uint8_t rbuf[5] = {0, 0, 0, 0, 0};
+  switch (nbphase) {
+  case MPL3115A2_PHASE_VIRGIN:
+  case MPL3115A2_PHASE_COMPLETE:
+    // Start a new measurement cycle.
+    _ctrl_reg1.bit.ALT = 0; // barometer (pressure) mode
+    _ctrl_reg1.bit.OST = 1; // initatiate a one-shot measurement
+    write8(MPL3115A2_CTRL_REG1, _ctrl_reg1.reg);
+    nbphase = MPL3115A2_PHASE_REQUESTED;
+    break;
+  case MPL3115A2_PHASE_REQUESTED:
+    if (read8(MPL3115A2_REGISTER_STATUS) & MPL3115A2_REGISTER_STATUS_PDR)
       nbphase = MPL3115A2_PHASE_MEASURED;
-      break;
-    case MPL3115A2_PHASE_MEASURED:
-      i2c_dev->write(wbuf,1,false);
-      i2c_dev->read(rbuf,5);
-      pval = uint32_t(rbuf[0]) << 16 | uint32_t(rbuf[1]) << 8 | uint32_t(rbuf[2]);
-      pressure = pval / 6400.0;
-      nbphase = MPL3115A2_PHASE_COMPLETE;
-      break;
+    break;
+  case MPL3115A2_PHASE_MEASURED:
+    i2c_dev->write(wbuf, 1, false);
+    i2c_dev->read(rbuf, 5);
+    pval = uint32_t(rbuf[0]) << 16 | uint32_t(rbuf[1]) << 8 | uint32_t(rbuf[2]);
+    pressure = pval / 6400.0;
+    nbphase = MPL3115A2_PHASE_COMPLETE;
+    break;
   }
   return nbphase;
 }
-
 
 /*!
  *  @brief  Get altitude

--- a/Adafruit_MPL3115A2.cpp
+++ b/Adafruit_MPL3115A2.cpp
@@ -68,6 +68,7 @@ boolean Adafruit_MPL3115A2::begin(TwoWire *twoWire) {
                                     MPL3115A2_PT_DATA_CFG_PDEFE |
                                     MPL3115A2_PT_DATA_CFG_DREM);
 
+  nbphase = MPL3115A2_PHASE_VIRGIN;
   return true;
 }
 
@@ -97,6 +98,42 @@ float Adafruit_MPL3115A2::getPressure() {
              uint32_t(buffer[2]);
   return float(pressure) / 6400.0;
 }
+
+/*!
+ *  @brief Get barometric pressure, non-blocking.
+ *  @param pressure Sensed pressure in hPa.
+ *  @return phase of the read operation. Returns 0 if pressure was written with valid data. Returns non-zero when function needs to be called again.
+ */
+uint8_t Adafruit_MPL3115A2::getPressureNonBlocking(float& pressure)
+{
+  uint32_t pval;
+  uint8_t wbuf[1] = {MPL3115A2_REGISTER_PRESSURE_MSB};
+  uint8_t rbuf[5] = {0,0,0,0,0};
+  switch(nbphase)
+  {
+    case MPL3115A2_PHASE_VIRGIN:
+    case MPL3115A2_PHASE_COMPLETE:
+      // Start a new measurement cycle.
+      _ctrl_reg1.bit.ALT = 0; // barometer (pressure) mode
+      _ctrl_reg1.bit.OST = 1; // initatiate a one-shot measurement
+      write8(MPL3115A2_CTRL_REG1, _ctrl_reg1.reg);
+      nbphase = MPL3115A2_PHASE_REQUESTED;
+      break;
+    case MPL3115A2_PHASE_REQUESTED:
+      if (read8(MPL3115A2_REGISTER_STATUS) & MPL3115A2_REGISTER_STATUS_PDR)
+      nbphase = MPL3115A2_PHASE_MEASURED;
+      break;
+    case MPL3115A2_PHASE_MEASURED:
+      i2c_dev->write(wbuf,1,false);
+      i2c_dev->read(rbuf,5);
+      pval = uint32_t(rbuf[0]) << 16 | uint32_t(rbuf[1]) << 8 | uint32_t(rbuf[2]);
+      pressure = pval / 6400.0;
+      nbphase = MPL3115A2_PHASE_COMPLETE;
+      break;
+  }
+  return nbphase;
+}
+
 
 /*!
  *  @brief  Get altitude

--- a/Adafruit_MPL3115A2.h
+++ b/Adafruit_MPL3115A2.h
@@ -101,10 +101,12 @@ enum {
 
 /** Phases for non blocking reads **/
 enum {
-  MPL3115A2_PHASE_VIRGIN = 0x01,	//!< No non-blocking operations have been done, yet.
-  MPL3115A2_PHASE_REQUESTED = 0x02,	//!< A measurement was requested.
-  MPL3115A2_PHASE_MEASURED = 0x03,	//!< A measurement was completed.
-  MPL3115A2_PHASE_COMPLETE = 0x00,	//!< The read op has been completed: we have valid data.
+  MPL3115A2_PHASE_VIRGIN =
+      0x01, //!< No non-blocking operations have been done, yet.
+  MPL3115A2_PHASE_REQUESTED = 0x02, //!< A measurement was requested.
+  MPL3115A2_PHASE_MEASURED = 0x03,  //!< A measurement was completed.
+  MPL3115A2_PHASE_COMPLETE =
+      0x00, //!< The read op has been completed: we have valid data.
 };
 
 #define MPL3115A2_REGISTER_STARTCONVERSION (0x12) ///< start conversion
@@ -118,7 +120,7 @@ public:
   Adafruit_MPL3115A2();
   boolean begin(TwoWire *twoWire = &Wire);
   float getPressure(void);
-  uint8_t getPressureNonBlocking(float& pressure); //!< Returns phase.
+  uint8_t getPressureNonBlocking(float &pressure); //!< Returns phase.
   float getAltitude(void);
   float getTemperature(void);
   void setSeaPressure(float SLP);
@@ -129,7 +131,7 @@ private:
   Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
   uint8_t read8(uint8_t a);
   uint8_t mode;
-  uint8_t nbphase;	//!< Phase in the non-blocking data read.
+  uint8_t nbphase; //!< Phase in the non-blocking data read.
 
   typedef union {
     struct {

--- a/Adafruit_MPL3115A2.h
+++ b/Adafruit_MPL3115A2.h
@@ -99,6 +99,14 @@ enum {
   MPL3115A2_CTRL_REG1_OS128 = 0x38,
 };
 
+/** Phases for non blocking reads **/
+enum {
+  MPL3115A2_PHASE_VIRGIN = 0x01,	//!< No non-blocking operations have been done, yet.
+  MPL3115A2_PHASE_REQUESTED = 0x02,	//!< A measurement was requested.
+  MPL3115A2_PHASE_MEASURED = 0x03,	//!< A measurement was completed.
+  MPL3115A2_PHASE_COMPLETE = 0x00,	//!< The read op has been completed: we have valid data.
+};
+
 #define MPL3115A2_REGISTER_STARTCONVERSION (0x12) ///< start conversion
 
 /*!
@@ -110,6 +118,7 @@ public:
   Adafruit_MPL3115A2();
   boolean begin(TwoWire *twoWire = &Wire);
   float getPressure(void);
+  uint8_t getPressureNonBlocking(float& pressure); //!< Returns phase.
   float getAltitude(void);
   float getTemperature(void);
   void setSeaPressure(float SLP);
@@ -120,6 +129,7 @@ private:
   Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
   uint8_t read8(uint8_t a);
   uint8_t mode;
+  uint8_t nbphase;	//!< Phase in the non-blocking data read.
 
   typedef union {
     struct {

--- a/examples/testmpl3115a2/testmpl3115a2.ino
+++ b/examples/testmpl3115a2/testmpl3115a2.ino
@@ -21,6 +21,8 @@
 
 #include <Adafruit_MPL3115A2.h>
 
+#undef TESTNONBLOCKING
+
 Adafruit_MPL3115A2 baro;
 
 void setup() {
@@ -39,6 +41,20 @@ void setup() {
   baro.setSeaPressure(1013.26);
 }
 
+#if defined(TESTNONBLOCKING)
+void loop() {
+  float pressure = 0;
+  uint8_t phase = baro.getPressureNonBlocking(pressure);
+  // If phase is zero, we have valid data, otherwise, we need to call again.
+  if (!phase)
+  {
+    Serial.print(pressure); Serial.println(" hPa");
+  }
+  else
+    Serial.println("...");
+  delay(100);
+}
+#else
 void loop() {
   float pressure = baro.getPressure();
   float altitude = baro.getAltitude();
@@ -51,3 +67,4 @@ void loop() {
 
   delay(250);
 }
+#endif

--- a/examples/testmpl3115a2/testmpl3115a2.ino
+++ b/examples/testmpl3115a2/testmpl3115a2.ino
@@ -27,12 +27,14 @@ Adafruit_MPL3115A2 baro;
 
 void setup() {
   Serial.begin(9600);
-  while(!Serial);
+  while (!Serial)
+    ;
   Serial.println("Adafruit_MPL3115A2 test!");
 
   if (!baro.begin()) {
     Serial.println("Could not find sensor. Check wiring.");
-    while(1);
+    while (1)
+      ;
   }
 
   // use to set sea level pressure for current location
@@ -46,11 +48,10 @@ void loop() {
   float pressure = 0;
   uint8_t phase = baro.getPressureNonBlocking(pressure);
   // If phase is zero, we have valid data, otherwise, we need to call again.
-  if (!phase)
-  {
-    Serial.print(pressure); Serial.println(" hPa");
-  }
-  else
+  if (!phase) {
+    Serial.print(pressure);
+    Serial.println(" hPa");
+  } else
     Serial.println("...");
   delay(100);
 }
@@ -61,9 +62,15 @@ void loop() {
   float temperature = baro.getTemperature();
 
   Serial.println("-----------------");
-  Serial.print("pressure = "); Serial.print(pressure); Serial.println(" hPa");
-  Serial.print("altitude = "); Serial.print(altitude); Serial.println(" m");
-  Serial.print("temperature = "); Serial.print(temperature); Serial.println(" C");
+  Serial.print("pressure = ");
+  Serial.print(pressure);
+  Serial.println(" hPa");
+  Serial.print("altitude = ");
+  Serial.print(altitude);
+  Serial.println(" m");
+  Serial.print("temperature = ");
+  Serial.print(temperature);
+  Serial.println(" C");
 
   delay(250);
 }


### PR DESCRIPTION
This change adds a non-blocking read for pressure data.

The existing code will block when reading pressure, and does `delay()` ops while the data is not ready.

The patch will add a new function: `uint8_t getPressureNonBlocking(float& pressure)` that will return immediately, without waiting.

If the function returns 0, the pressure data is valid, and ready for consumption by the app.

If the function returns non-zero, it needs to be called again.

To test: define `TESTNONBLOCKING` in the example code.

**NOTE:** This patch does not alter the behaviour of existing code, and is safe to incorporate.
