### PR TITLE
Add altitude offset

### DIFF
--- a/Adafruit_MPL3115A2.cpp
+++ b/Adafruit_MPL3115A2.cpp
@@ -126,6 +126,22 @@ float Adafruit_MPL3115A2::getAltitude() {
 }
 
 /*!
+ *  @brief  Get the altitude offset
+ *  @return Offset value in meters
+ */
+int8_t Adafruit_MPL3115A2::getAltitudeOffset(void) {
+  return int(read8(MPL3115A2_OFF_H));
+}
+
+/*!
+ *  @brief  Set the altitude offset
+ *  @param offset Offset value in meters, from -127 to 128
+ */
+void Adafruit_MPL3115A2::setAltitudeOffset(int8_t offset) {
+  write8(MPL3115A2_OFF_H, uint8_t(offset));
+}
+
+/*!
  *  @brief  Set the local sea level pressure
  *  @param SLP sea level pressure in hPa
  */

--- a/Adafruit_MPL3115A2.cpp
+++ b/Adafruit_MPL3115A2.cpp
@@ -130,7 +130,7 @@ float Adafruit_MPL3115A2::getAltitude() {
  *  @return Offset value in meters
  */
 int8_t Adafruit_MPL3115A2::getAltitudeOffset(void) {
-  return int(read8(MPL3115A2_OFF_H));
+  return int8_t(read8(MPL3115A2_OFF_H));
 }
 
 /*!

--- a/Adafruit_MPL3115A2.h
+++ b/Adafruit_MPL3115A2.h
@@ -50,6 +50,8 @@ enum {
 
   MPL3115A2_BAR_IN_MSB = (0x14),
   MPL3115A2_BAR_IN_LSB = (0x15),
+
+  MPL3115A2_OFF_H = (0x2D),
 };
 
 /** MPL3115A2 status register bits **/
@@ -111,6 +113,8 @@ public:
   boolean begin(TwoWire *twoWire = &Wire);
   float getPressure(void);
   float getAltitude(void);
+  int8_t getAltitudeOffset(void);
+  void setAltitudeOffset(int8_t offset);
   float getTemperature(void);
   void setSeaPressure(float SLP);
 


### PR DESCRIPTION
For #24. Adds a getter/setter for the Altitude Data User Offset Register.

Test sketch:
```cpp
#include <Adafruit_MPL3115A2.h>

Adafruit_MPL3115A2 mpl;

void setup() {
  Serial.begin(9600);
  while(!Serial);
  Serial.println("Adafruit_MPL3115A2 test!");

  if (!mpl.begin()) {
    Serial.println("Could not find sensor. Check wiring.");
    while(1);
  }

  Serial.print("Pressure = "); Serial.println(mpl.getPressure());
  Serial.print("Temperature = "); Serial.println(mpl.getTemperature());
  Serial.println();
  
  mpl.setAltitudeOffset(0);
  Serial.print("Altitude = "); Serial.print(mpl.getAltitude());
  Serial.print("  |  offset = "); Serial.println(mpl.getAltitudeOffset());
  mpl.setAltitudeOffset(-42);
  Serial.print("Altitude = "); Serial.print(mpl.getAltitude());
  Serial.print("  |  offset = "); Serial.println(mpl.getAltitudeOffset());
  mpl.setAltitudeOffset(23);
  Serial.print("Altitude = "); Serial.print(mpl.getAltitude());
  Serial.print("  |  offset = "); Serial.println(mpl.getAltitudeOffset());
  mpl.setAltitudeOffset(0);
  Serial.print("Altitude = "); Serial.print(mpl.getAltitude());
  Serial.print("  |  offset = "); Serial.println(mpl.getAltitudeOffset());
}

void loop() {
}
```

Results:
```
Adafruit_MPL3115A2 test!
Pressure = 1003.79
Temperature = 27.44

Altitude = 73.87  |  offset = 0
Altitude = 31.00  |  offset = -42
Altitude = 95.25  |  offset = 23
Altitude = 72.00  |  offset = 0
```