### PR TITLE
Add new methods to support async reading

### DIFF
--- a/Adafruit_MPL3115A2.h
+++ b/Adafruit_MPL3115A2.h
@@ -99,6 +99,17 @@ enum {
   MPL3115A2_CTRL_REG1_OS128 = 0x38,
 };
 
+typedef enum {
+  MPL3115A2_BAROMETER = 0,
+  MPL3115A2_ALTIMETER,
+} mpl3115a2_mode_t;
+
+typedef enum {
+  MPL3115A2_PRESSURE,
+  MPL3115A2_ALTITUDE,
+  MPL3115A2_TEMPERATURE,
+} mpl3115a2_meas_t;
+
 #define MPL3115A2_REGISTER_STARTCONVERSION (0x12) ///< start conversion
 
 /*!
@@ -114,12 +125,17 @@ public:
   float getTemperature(void);
   void setSeaPressure(float SLP);
 
+  void setMode(mpl3115a2_mode_t mode = MPL3115A2_BAROMETER);
+  void startOneShot(void);
+  bool conversionComplete(void);
+  float getLastConversionResults(mpl3115a2_meas_t value = MPL3115A2_PRESSURE);
+
   void write8(uint8_t a, uint8_t d);
 
 private:
   Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
   uint8_t read8(uint8_t a);
-  uint8_t mode;
+  mpl3115a2_mode_t currentMode;
 
   typedef union {
     struct {

--- a/Adafruit_MPL3115A2.h
+++ b/Adafruit_MPL3115A2.h
@@ -99,11 +99,13 @@ enum {
   MPL3115A2_CTRL_REG1_OS128 = 0x38,
 };
 
+/** MPL3115A2 measurement modes **/
 typedef enum {
   MPL3115A2_BAROMETER = 0,
   MPL3115A2_ALTIMETER,
 } mpl3115a2_mode_t;
 
+/** MPL3115A2 measurement types **/
 typedef enum {
   MPL3115A2_PRESSURE,
   MPL3115A2_ALTITUDE,

--- a/examples/mpl3115a2_async/mpl3115a2_async.ino
+++ b/examples/mpl3115a2_async/mpl3115a2_async.ino
@@ -1,0 +1,45 @@
+/**
+ * Async example for MPL3115A2
+ */
+
+#include <Adafruit_MPL3115A2.h>
+
+Adafruit_MPL3115A2 mpl;
+
+void setup() {
+  Serial.begin(9600);
+  while(!Serial);
+  Serial.println("Adafruit_MPL3115A2 test!");
+
+  if (!mpl.begin()) {
+    Serial.println("Could not find sensor. Check wiring.");
+    while(1);
+  }
+
+  // set mode before starting a conversion
+  Serial.println("Setting mode to barometer (pressure).");
+  mpl.setMode(MPL3115A2_BAROMETER);
+}
+
+void loop() {
+  // start a conversion
+  Serial.println("Starting a conversion.");
+  mpl.startOneShot();
+
+  // do something else while waiting
+  Serial.println("Counting number while waiting...");
+  int count = 0;
+  while (!mpl.conversionComplete()) {
+    count++;
+  }
+  Serial.print("Done! Counted to "); Serial.println(count);
+
+  // now get results
+  Serial.print("Pressure = ");
+  Serial.println(mpl.getLastConversionResults(MPL3115A2_PRESSURE));
+  Serial.print("Temperature = ");
+  Serial.println(mpl.getLastConversionResults(MPL3115A2_TEMPERATURE));
+  Serial.println();
+
+  delay(1000);
+}


### PR DESCRIPTION
For #11. Adds new methods to support async readings. Also adds new example.

Existing simple blocking example `testmpl3115a2.ino` works same as before:
```
Adafruit_MPL3115A2 test!
Pressure = 1003.89
Temperature = 26.37
```

New `mpl3115a2_aync.ino` example:
```
Adafruit_MPL3115A2 test!
Setting mode to barometer (pressure).
Starting a conversion.
Counting number while waiting...
Done! Counted to 866
Pressure = 1003.84
Temperature = 26.31

Starting a conversion.
Counting number while waiting...
Done! Counted to 866
Pressure = 1003.83
Temperature = 26.31

Starting a conversion.
Counting number while waiting...
Done! Counted to 866
Pressure = 1003.84
Temperature = 26.31
```
