### PR TITLE
Add setOversampleRate

### DIFF
--- a/Adafruit_MPL3115A2.cpp
+++ b/Adafruit_MPL3115A2.cpp
@@ -133,10 +133,9 @@ void Adafruit_MPL3115A2::setSeaPressure(float SLP) {
 }
 
 /*!
- *    Call with a rate from 0 to 7. See page 33 for table of ratios.
- *    Sets the over sample rate. Datasheet calls for 128 but you can set it
- *    from 1 to 128 samples. The higher the oversample rate the greater
- *    the time between data samples.
+ *  @brief Set the oversample rate 
+ *  @param setOversampleRate over sample rate from 0 to 7
+ * The higher the oversample rate the more time between samples
  */
 void Adafruit_MPL3115A2::setOversampleRate(int8_t sampleRate) {
   if (sampleRate > 7)

--- a/Adafruit_MPL3115A2.cpp
+++ b/Adafruit_MPL3115A2.cpp
@@ -133,7 +133,7 @@ void Adafruit_MPL3115A2::setSeaPressure(float SLP) {
 }
 
 /*!
- *  @brief Set the oversample rate 
+ *  @brief Set the oversample rate
  *  @param setOversampleRate over sample rate from 0 to 7
  * The higher the oversample rate the more time between samples
  */

--- a/Adafruit_MPL3115A2.cpp
+++ b/Adafruit_MPL3115A2.cpp
@@ -134,18 +134,18 @@ void Adafruit_MPL3115A2::setSeaPressure(float SLP) {
 
 /*!
  *    Call with a rate from 0 to 7. See page 33 for table of ratios.
- *    Sets the over sample rate. Datasheet calls for 128 but you can set it 
+ *    Sets the over sample rate. Datasheet calls for 128 but you can set it
  *    from 1 to 128 samples. The higher the oversample rate the greater
  *    the time between data samples.
- */ 
-void Adafruit_MPL3115A2::setOversampleRate(int8_t sampleRate)
-{
-  if(sampleRate > 7) sampleRate = 7; //OS cannot be larger than 0b.0111
-  sampleRate <<= 3; //Align it for the CTRL_REG1 register
-  
-  int8_t tempSetting = read8(MPL3115A2_CTRL_REG1); //Read current settings
-  tempSetting &= 0xc7; // B11000111; //Clear out old OS bits
-  tempSetting |= sampleRate; //Mask in new OS bits
+ */
+void Adafruit_MPL3115A2::setOversampleRate(int8_t sampleRate) {
+  if (sampleRate > 7)
+    sampleRate = 7; // OS cannot be larger than 0b.0111
+  sampleRate <<= 3; // Align it for the CTRL_REG1 register
+
+  int8_t tempSetting = read8(MPL3115A2_CTRL_REG1); // Read current settings
+  tempSetting &= 0xc7;       // B11000111; //Clear out old OS bits
+  tempSetting |= sampleRate; // Mask in new OS bits
   write8(MPL3115A2_CTRL_REG1, tempSetting);
 }
 

--- a/Adafruit_MPL3115A2.cpp
+++ b/Adafruit_MPL3115A2.cpp
@@ -133,6 +133,23 @@ void Adafruit_MPL3115A2::setSeaPressure(float SLP) {
 }
 
 /*!
+ *    Call with a rate from 0 to 7. See page 33 for table of ratios.
+ *    Sets the over sample rate. Datasheet calls for 128 but you can set it 
+ *    from 1 to 128 samples. The higher the oversample rate the greater
+ *    the time between data samples.
+ */ 
+void Adafruit_MPL3115A2::setOversampleRate(int8_t sampleRate)
+{
+  if(sampleRate > 7) sampleRate = 7; //OS cannot be larger than 0b.0111
+  sampleRate <<= 3; //Align it for the CTRL_REG1 register
+  
+  int8_t tempSetting = read8(MPL3115A2_CTRL_REG1); //Read current settings
+  tempSetting &= 0xc7; // B11000111; //Clear out old OS bits
+  tempSetting |= sampleRate; //Mask in new OS bits
+  write8(MPL3115A2_CTRL_REG1, tempSetting);
+}
+
+/*!
  *  @brief  Get temperature
  *  @return temperature reading as a floating-point value in degC
  */

--- a/Adafruit_MPL3115A2.cpp
+++ b/Adafruit_MPL3115A2.cpp
@@ -134,7 +134,7 @@ void Adafruit_MPL3115A2::setSeaPressure(float SLP) {
 
 /*!
  *  @brief Set the oversample rate
- *  @param setOversampleRate over sample rate from 0 to 7
+ *  @param sampleRate oversample rate from 0 to 7
  * The higher the oversample rate the more time between samples
  */
 void Adafruit_MPL3115A2::setOversampleRate(int8_t sampleRate) {

--- a/Adafruit_MPL3115A2.h
+++ b/Adafruit_MPL3115A2.h
@@ -130,8 +130,7 @@ public:
   void setAltitudeOffset(int8_t offset);
   float getTemperature(void);
   void setSeaPressure(float SLP);
-  void setOversampleRate(
-      int8_t sampleRate); ///< sampleRate from 0 to 7. Smaller is faster
+  void setOversampleRate(int8_t sampleRate); ///< sampleRate from 0 to 7
   void setMode(mpl3115a2_mode_t mode = MPL3115A2_BAROMETER);
   void startOneShot(void);
   bool conversionComplete(void);

--- a/Adafruit_MPL3115A2.h
+++ b/Adafruit_MPL3115A2.h
@@ -130,7 +130,7 @@ public:
   void setAltitudeOffset(int8_t offset);
   float getTemperature(void);
   void setSeaPressure(float SLP);
-  void setOversampleRate(int8_t sampleRate);
+  void setOversampleRate(int8_t sampleRate); ///< Sample rate from 0 to 7. See page 33 for table of ratios
   void setMode(mpl3115a2_mode_t mode = MPL3115A2_BAROMETER);
   void startOneShot(void);
   bool conversionComplete(void);

--- a/Adafruit_MPL3115A2.h
+++ b/Adafruit_MPL3115A2.h
@@ -130,7 +130,8 @@ public:
   void setAltitudeOffset(int8_t offset);
   float getTemperature(void);
   void setSeaPressure(float SLP);
-  void setOversampleRate(int8_t sampleRate); ///< Sample rate from 0 to 7. See page 33 for table of ratios
+  void setOversampleRate(
+      int8_t sampleRate); ///< sampleRate from 0 to 7. Smaller is faster
   void setMode(mpl3115a2_mode_t mode = MPL3115A2_BAROMETER);
   void startOneShot(void);
   bool conversionComplete(void);

--- a/Adafruit_MPL3115A2.h
+++ b/Adafruit_MPL3115A2.h
@@ -130,7 +130,7 @@ public:
   void setAltitudeOffset(int8_t offset);
   float getTemperature(void);
   void setSeaPressure(float SLP);
-  void setOversampleRate(int8_t sampleRate); ///< sampleRate from 0 to 7
+  void setOversampleRate(int8_t sampleRate);
   void setMode(mpl3115a2_mode_t mode = MPL3115A2_BAROMETER);
   void startOneShot(void);
   bool conversionComplete(void);

--- a/Adafruit_MPL3115A2.h
+++ b/Adafruit_MPL3115A2.h
@@ -130,7 +130,7 @@ public:
   void setAltitudeOffset(int8_t offset);
   float getTemperature(void);
   void setSeaPressure(float SLP);
-
+  void setOversampleRate(int8_t sampleRate);
   void setMode(mpl3115a2_mode_t mode = MPL3115A2_BAROMETER);
   void startOneShot(void);
   bool conversionComplete(void);


### PR DESCRIPTION
This change allows users to chose the over sample rate in their .ino file, instead of the value being hard coded in the library. Changing this value can allow for much faster read rates for the barometer.